### PR TITLE
Override metrics endpoint

### DIFF
--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -26,7 +26,10 @@ patches:
         value: "/afk-no/api/acos/instances"
       - op: replace
         path: "/spec/probes/readiness/path"
-        value: "/afk-no/actuator/health"
+        value: "/afk-no/actuator/health" 
+      - op: replace
+        path: "/spec/observability/metrics/path"
+        value: "/afk-no/actuator/prometheus"
 
     target:
       kind: Application

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -27,6 +27,9 @@ patches:
       - op: replace
         path: "/spec/probes/readiness/path"
         value: "/beta/afk-no/actuator/health"
+      - op: replace
+        path: "/spec/observability/metrics/path"
+        value: "/beta/afk-no/actuator/prometheus"
 
     target:
       kind: Application

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -27,6 +27,9 @@ patches:
       - op: replace
         path: "/spec/probes/readiness/path"
         value: "/bfk-no/actuator/health"
+      - op: replace
+        path: "/spec/observability/metrics/path"
+        value: "/bfk-no/actuator/prometheus"
 
     target:
       kind: Application

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -27,6 +27,9 @@ patches:
       - op: replace
         path: "/spec/probes/readiness/path"
         value: "/beta/bfk-no/actuator/health"
+      - op: replace
+        path: "/spec/observability/metrics/path"
+        value: "/beta/bfk-no/actuator/prometheus"
 
     target:
       kind: Application

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -27,6 +27,9 @@ patches:
       - op: replace
         path: "/spec/probes/readiness/path"
         value: "/ofk-no/actuator/health"
+      - op: replace
+        path: "/spec/observability/metrics/path"
+        value: "/ofk-no/actuator/prometheus"
 
     target:
       kind: Application

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -27,6 +27,9 @@ patches:
       - op: replace
         path: "/spec/probes/readiness/path"
         value: "/beta/ofk-no/actuator/health"
+      - op: replace
+        path: "/spec/observability/metrics/path"
+        value: "/beta/ofk-no/actuator/prometheus"
 
     target:
       kind: Application


### PR DESCRIPTION
/actuator/prometheus is not available, so have to use /{fylke}/actuator/prometheus instead.