### PR TITLE
FFS-2190: Oppgrader ACOS-gateway til web-instance-gateway 3.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,8 @@ dependencies {
     implementation("no.novari:fint-arkiv-resource-model-java:$fintResourceModelVersion")
     implementation("no.novari:fint-administrasjon-resource-model-java:$fintResourceModelVersion")
 
-    implementation("no.novari:flyt-web-instance-gateway:2.4.0")
+    implementation("no.novari:flyt-web-instance-gateway:3.0.0-rc-1")
+    implementation("no.novari:flyt-cache:3.0.0")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-core")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
     implementation("no.novari:fint-arkiv-resource-model-java:$fintResourceModelVersion")
     implementation("no.novari:fint-administrasjon-resource-model-java:$fintResourceModelVersion")
 
-    implementation("no.novari:flyt-web-instance-gateway:3.0.0-rc-1")
+    implementation("no.novari:flyt-web-instance-gateway:3.0.0-rc-2")
     implementation("no.novari:flyt-cache:3.0.0")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
     implementation("no.novari:fint-arkiv-resource-model-java:$fintResourceModelVersion")
     implementation("no.novari:fint-administrasjon-resource-model-java:$fintResourceModelVersion")
 
-    implementation("no.novari:flyt-web-instance-gateway:3.0.0-rc-2")
+    implementation("no.novari:flyt-web-instance-gateway:3.0.0-rc-3")
     implementation("no.novari:flyt-cache:3.0.0")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
     implementation("no.novari:fint-arkiv-resource-model-java:$fintResourceModelVersion")
     implementation("no.novari:fint-administrasjon-resource-model-java:$fintResourceModelVersion")
 
-    implementation("no.novari:flyt-web-instance-gateway:3.0.0-rc-3")
+    implementation("no.novari:flyt-web-instance-gateway:3.0.0")
     implementation("no.novari:flyt-cache:3.0.0")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")


### PR DESCRIPTION
## Summary

Implements [FFS-2190](https://novari-iks.atlassian.net/browse/FFS-2190).

- Oppgraderer til `flyt-web-instance-gateway:3.0.0`.
- Arver web-resource-server 4.0.0 gjennom web-instance-gateway uten direkte avhengighet.

[FFS-2190]: https://novari-iks.atlassian.net/browse/FFS-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ