### PR TITLE
FFS-2233 Add OpenTelemetry rollout

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "13.1.0"
     kotlin("jvm") version "2.3.10"
     kotlin("plugin.spring") version "2.3.10"
+    kotlin("kapt") version "2.3.10"
 }
 
 group = "no.novari"
@@ -36,21 +37,26 @@ dependencies {
     compileOnly("org.springframework.security:spring-security-config")
     compileOnly("org.springframework.security:spring-security-web")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("net.logstash.logback:logstash-logback-encoder:9.0")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+    kapt("org.springframework.boot:spring-boot-configuration-processor")
 
     implementation("no.novari:fint-model-resource:$fintModelResourceVersion")
     implementation("no.novari:fint-arkiv-resource-model-java:$fintResourceModelVersion")
     implementation("no.novari:fint-administrasjon-resource-model-java:$fintResourceModelVersion")
 
-    implementation("no.novari:flyt-web-instance-gateway:3.0.0")
+    implementation("no.novari:flyt-web-instance-gateway:3.1.0-rc-3")
     implementation("no.novari:flyt-cache:3.0.0")
+    implementation("no.novari:telemetry-starter:0.0.4")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-core")
     testImplementation("org.mockito.kotlin:mockito-kotlin:6.2.3")
+    testImplementation(kotlin("test"))
 }
 
 tasks.test {

--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/afk-no"
 

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -41,8 +41,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/afk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/bfk-no"
 

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -41,8 +41,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/bfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/ofk-no"
 

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -41,8 +41,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/ofk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/src/main/kotlin/no/novari/flyt/acos/instance/gateway/caseinfo/CaseInfoMappingService.kt
+++ b/src/main/kotlin/no/novari/flyt/acos/instance/gateway/caseinfo/CaseInfoMappingService.kt
@@ -1,5 +1,6 @@
 package no.novari.flyt.acos.instance.gateway.caseinfo
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.cache.FintCache
 import no.novari.fint.model.resource.administrasjon.personal.PersonalressursResource
 import no.novari.fint.model.resource.arkiv.kodeverk.SaksstatusResource
@@ -12,7 +13,6 @@ import no.novari.flyt.acos.instance.gateway.model.caseinfo.AdministrativeUnit
 import no.novari.flyt.acos.instance.gateway.model.caseinfo.CaseInfo
 import no.novari.flyt.acos.instance.gateway.model.caseinfo.CaseManager
 import no.novari.flyt.acos.instance.gateway.model.caseinfo.CaseStatus
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -71,7 +71,11 @@ class CaseInfoMappingService(
                 phone = personResource.kontaktinformasjon.mobiltelefonnummer,
             )
         }.getOrElse { exception ->
-            log.warn("No case manager for case with mappeId='{}'", caseResource.mappeId.identifikatorverdi, exception)
+            log.atWarn {
+                message = "No case manager for case with mappeId={}"
+                arguments = arrayOf(caseResource.mappeId.identifikatorverdi)
+                cause = exception
+            }
             null
         }
     }
@@ -88,11 +92,11 @@ class CaseInfoMappingService(
                 )
             AdministrativeUnit(name = administrativeUnitResource.navn)
         }.getOrElse { exception ->
-            log.warn(
-                "No administrative unit for case with mappeId='{}'",
-                caseResource.mappeId.identifikatorverdi,
-                exception,
-            )
+            log.atWarn {
+                message = "No administrative unit for case with mappeId={}"
+                arguments = arrayOf(caseResource.mappeId.identifikatorverdi)
+                cause = exception
+            }
             null
         }
     }
@@ -112,12 +116,16 @@ class CaseInfoMappingService(
                 code = caseStatusResource.kode,
             )
         }.getOrElse { exception ->
-            log.warn("No status for case with mappeId='{}'", caseResource.mappeId.identifikatorverdi, exception)
+            log.atWarn {
+                message = "No status for case with mappeId={}"
+                arguments = arrayOf(caseResource.mappeId.identifikatorverdi)
+                cause = exception
+            }
             null
         }
     }
 
     private companion object {
-        private val log = LoggerFactory.getLogger(CaseInfoMappingService::class.java)
+        private val log = KotlinLogging.logger {}
     }
 }

--- a/src/main/resources/application-flyt-kafka.yaml
+++ b/src/main/resources/application-flyt-kafka.yaml
@@ -3,6 +3,8 @@ novari:
     topic:
       domain-context: flyt
     application-id: ${fint.application-id}
+    tracing:
+      enabled: true
 
 spring:
   kafka:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,6 +12,8 @@ server:
   max-http-request-header-size: 40KB
 
 spring:
+  application:
+    name: ${fint.application-id}
   profiles:
     include:
       - flyt-kafka

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,8 @@
+<configuration scan="true">
+
+    <include resource="no/novari/telemetry/logback-json.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="TELEMETRY_JSON"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

Adds OpenTelemetry rollout wiring for HTTP and Kafka tracing in fint-flyt-acos-gateway as part of [FFS-2233](https://novari-iks.atlassian.net/browse/FFS-2233).

- Bumps `no.novari:flyt-web-instance-gateway` to `3.1.0-rc-3` and adds `no.novari:telemetry-starter:0.0.4`.
- Sets `spring.application.name` and enables Kafka tracing with `novari.kafka.tracing.enabled=true`.
- Adds telemetry org IDs to all overlays and configures the OTLP exporter endpoint only for beta overlays.
- Switches logging to kotlin-logging and the shared telemetry JSON logback configuration.

## Validation

- `kustomize build` for all `afk-no`, `bfk-no`, and `ofk-no` api/beta overlays.
- `./gradlew check`.

[FFS-2233]: https://novari-iks.atlassian.net/browse/FFS-2233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ